### PR TITLE
ci(frontend): add install+build workflow

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,26 @@
+name: frontend-ci
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build
+        working-directory: frontend
+        run: npm run build


### PR DESCRIPTION
**This PR introduces our first CI pipeline for the frontend.**

**What’s included:**
* Adds GitHub Actions workflow: frontend-ci
* Triggers on pull_request and pushes to main
* Uses Node.js 20 with npm dependency caching
* Runs in /frontend:
- npm ci
- npm run build

**Purpose:**
Prevent broken frontend builds from being merged into main by verifying the build on a new, clean runner/machine.

**How to verify this:**
* Open PR -> check “Checks” tab -> frontend-ci / build should run
* Workflow should fail if build breaks, To validate failure behavior: break the build in a commit and verify the check turns red